### PR TITLE
Fixed crash when knot server is not configured

### DIFF
--- a/knot_exporter
+++ b/knot_exporter
@@ -431,18 +431,19 @@ class KnotCollector(object):
         ctl.send_block(cmd="zone-stats", flags="F")
         zone_stats = ctl.receive_stats()
 
-        for zone, zone_data in zone_stats["zone"].items():
-            for section, section_data in zone_data.items():
-                for item, item_data in section_data.items():
-                    for kind, kind_data in item_data.items():
-                        if kind_data == 0:
-                            continue
+        if "zone" in zone_stats:
+            for zone, zone_data in zone_stats["zone"].items():
+                for section, section_data in zone_data.items():
+                    for item, item_data in section_data.items():
+                        for kind, kind_data in item_data.items():
+                            if kind_data == 0:
+                                continue
 
-                        name = ('knot_' + item).replace('-', '_')
-                        m = GaugeMetricFamily(name, '',
-                                labels=['zone', 'section', 'type'])
-                        m.add_metric([zone, section, kind], kind_data)
-                        yield m
+                            name = ('knot_' + item).replace('-', '_')
+                            m = GaugeMetricFamily(name, '',
+                                    labels=['zone', 'section', 'type'])
+                            m.add_metric([zone, section, kind], kind_data)
+                            yield m
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
This fix solves the problem that the exporter crashes when knot is not configured with any zones.