### PR TITLE
Fixed systemd service dependencies

### DIFF
--- a/knot_exporter.service
+++ b/knot_exporter.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Prometheus exporter for Knot DNS
 Documentation=https://github.com/ghedo/knot_exporter
+After=knot.service
+Requires=knot.service
 
 [Service]
 Restart=always


### PR DESCRIPTION
Hi, I've fixed the systemd unit file so that the exporter won't be started sooner than knot itself. In such a case the exporter crashes because of missing socket file.