### PR TITLE
Fix crash with all metrics enabled in Knot DNS 2.9.1

### DIFF
--- a/knot_exporter
+++ b/knot_exporter
@@ -424,8 +424,17 @@ class KnotCollector(object):
 
         for section, section_data in global_stats.items():
             for item, item_data in section_data.items():
-                name = ('knot_' + section + '_' + item).replace('-', '_')
-                yield GaugeMetricFamily(name, '', value=item_data)
+                if type(item_data) == dict:
+                    for kind, value in item_data.items():
+                        kind_sect = kind.lower()
+                        yield GaugeMetricFamily(
+                            (f"knot_{section}_{item}_{kind_sect}").replace('-', '_'),
+                            '',
+                            value
+                        )
+                else:
+                    name = ('knot_' + section + '_' + item).replace('-', '_')
+                    yield GaugeMetricFamily(name, '', value=item_data)
 
         # Get zone metrics.
         ctl.send_block(cmd="zone-stats", flags="F")


### PR DESCRIPTION
I basically have the following configuration for stats running on my
self-hosted Knot:

    template:
      - id: default
        # ...
        global-module: mod-stats

    mod-stats:
      - id: custom
        edns-presence: on
        query-type: on

    zone:
      - domain: example.com
        file: example.com.zone
        module: mod-stats/custom

When running this script as prometheus exporter against this instance,
I get no response and the log is full of errors like this:

    ----------------------------------------
    Exception happened during processing of request from ('...', 42884)
    Traceback (most recent call last):
      File "/nix/store/xibghivp12jgk2xrwykpxxhy8wbmr5zi-python3-3.8.8/lib/python3.8/socketserver.py", line 316, in _handle_request_noblock
        self.process_request(request, client_address)
      File "/nix/store/xibghivp12jgk2xrwykpxxhy8wbmr5zi-python3-3.8.8/lib/python3.8/socketserver.py", line 347, in process_request
        self.finish_request(request, client_address)
      File "/nix/store/xibghivp12jgk2xrwykpxxhy8wbmr5zi-python3-3.8.8/lib/python3.8/socketserver.py", line 360, in finish_request
        self.RequestHandlerClass(request, client_address, self)
      File "/nix/store/xibghivp12jgk2xrwykpxxhy8wbmr5zi-python3-3.8.8/lib/python3.8/socketserver.py", line 720, in __init__
        self.handle()
      File "/nix/store/xibghivp12jgk2xrwykpxxhy8wbmr5zi-python3-3.8.8/lib/python3.8/http/server.py", line 427, in handle
        self.handle_one_request()
      File "/nix/store/xibghivp12jgk2xrwykpxxhy8wbmr5zi-python3-3.8.8/lib/python3.8/http/server.py", line 415, in handle_one_request
        method()
      File "/nix/store/ncykydvnwbs4zfg6aribydwfcbgbawal-python3.8-prometheus_client-0.8.0/lib/python3.8/site-packages/prometheus_client/exposition.py", line 169, in do_GET
        status, header, output = _bake_output(registry, accept_header, params)
      File "/nix/store/ncykydvnwbs4zfg6aribydwfcbgbawal-python3.8-prometheus_client-0.8.0/lib/python3.8/site-packages/prometheus_client/exposition.py", line 40, in _bake_output
        output = encoder(registry)
      File "/nix/store/ncykydvnwbs4zfg6aribydwfcbgbawal-python3.8-prometheus_client-0.8.0/lib/python3.8/site-packages/prometheus_client/openmetrics/exposition.py", line 56, in generate_latest
        floatToGoString(s.value),
      File "/nix/store/ncykydvnwbs4zfg6aribydwfcbgbawal-python3.8-prometheus_client-0.8.0/lib/python3.8/site-packages/prometheus_client/utils.py", line 9, in floatToGoString
        d = float(d)
    TypeError: ("float() argument must be a string or a number, not 'dict'", Metric(knot_mod_stats_request_protocol, , gauge, , [Sample(name='knot_mod_stats_request_protocol', labels={}, value={'udp4': 0, 'tcp4': 0, 'udp6': 32, 'tcp6': 2}, timestamp=None, exemplar=None)]))
    ----------------------------------------

This happens because `item_data` in `KnotCollector` can sometimes be a
dict containing stats (but not always, for instance the `zone-count`
which is always available is a simple number). I decided to just expose
all the metrics in the dict now which fixes the error and should add a
few more metrics to this exporter including

* Amount of connections to Knot grouped by protocol ({udp,tcp}{4,6}).
* Amount of AXFR zone transfers

and a few more.